### PR TITLE
TD-31 프로필 수정 컴포넌트 UI 개발 / TD-33 프로필 조회 및 수정 API 구현

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
-	"plugins": ["prettier-plugin-tailwindcss"],
+	"plugins": [
+		"prettier-plugin-tailwindcss"
+	],
 	"tabWidth": 2,
 	"semi": true,
 	"bracketSpacing": true,

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,18 +1,18 @@
-import type { StorybookConfig } from "@storybook/nextjs-vite";
+import type { StorybookConfig } from '@storybook/nextjs-vite';
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
-  addons: [
-    "@chromatic-com/storybook",
-    "@storybook/addon-docs",
-    "@storybook/addon-onboarding",
-    "@storybook/addon-a11y",
-    "@storybook/addon-vitest",
-  ],
-  framework: {
-    name: "@storybook/nextjs-vite",
-    options: {},
-  },
-  staticDirs: ["../public"],
+	stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+	addons: [
+		'@chromatic-com/storybook',
+		'@storybook/addon-docs',
+		'@storybook/addon-onboarding',
+		'@storybook/addon-a11y',
+		'@storybook/addon-vitest',
+	],
+	framework: {
+		name: '@storybook/nextjs-vite',
+		options: {}
+	},
+	staticDirs: ['../public']
 };
 export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,21 +1,50 @@
-import type { Preview } from "@storybook/nextjs-vite";
+import type { Preview } from '@storybook/nextjs-vite';
+import '../src/styles/globals.css';
+
+const customViewports = {
+	desktop: {
+		name: 'Desktop',
+		styles: {
+			width: '1920px',
+			height: '800px'
+		}
+	},
+	tablet: {
+		name: 'Tablet',
+		styles: {
+			width: '745px',
+			height: '800px'
+		}
+	},
+	mobile: {
+		name: 'Mobile',
+		styles: {
+			width: '375px',
+			height: '800px'
+		}
+	}
+};
 
 const preview: Preview = {
-  parameters: {
-    controls: {
-      matchers: {
-        color: /(background|color)$/i,
-        date: /Date$/i,
-      },
-    },
-
-    a11y: {
-      // 'todo' - show a11y violations in the test UI only
-      // 'error' - fail CI on a11y violations
-      // 'off' - skip a11y checks entirely
-      test: "todo",
-    },
-  },
+	parameters: {
+		viewport: {
+			options: {
+				...customViewports
+			}
+		},
+		controls: {
+			matchers: {
+				color: /(background|color)$/i,
+				date: /Date$/i
+			}
+		},
+		a11y: {
+			// 'todo' - show a11y violations in the test UI only
+			// 'error' - fail CI on a11y violations
+			// 'off' - skip a11y checks entirely
+			test: 'todo'
+		}
+	}
 };
 
 export default preview;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,17 +1,19 @@
-import type { Config } from "jest";
-import nextJest from "next/jest.js";
+import type { Config } from 'jest';
+import nextJest from 'next/jest.js';
 
 const createJestConfig = nextJest({
-  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
-  dir: "./",
+	// Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+	dir: './'
 });
 
 // Add any custom config to be passed to Jest
 const config: Config = {
-  coverageProvider: "v8",
-  testEnvironment: "jsdom",
-  // 테스트 전에 실행할 설정 파일을 지정
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+	coverageProvider: 'v8',
+	testEnvironment: 'jsdom',
+	// 테스트 전에 실행할 설정 파일을 지정
+	setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+	// Jest 실행 시 playwright 테스트 제외
+	testPathIgnorePatterns: ['/node_modules/', 'e2e']
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/src/apis/users/index.test.ts
+++ b/src/apis/users/index.test.ts
@@ -1,0 +1,124 @@
+import { getUserInfo, updateUserInfo } from '.';
+import { UserInfo } from '@/types/user';
+
+global.fetch = jest.fn();
+
+describe('사용자 API 테스트', () => {
+	const mockTeamId = 'team5';
+
+	const mockUser: UserInfo = {
+		teamId: 1,
+		id: 1,
+		email: 'codeit@test.com',
+		name: 'Test',
+		companyName: 'Codeit',
+		image: '/Codeit.png',
+		createdAt: '2025-09-25T01:34:15.645Z',
+		updatedAt: '2025-09-25T01:34:15.645Z'
+	};
+
+	beforeEach(() => {
+		(fetch as jest.Mock).mockReset();
+	});
+
+	test('getUserInfo는 사용자 정보를 반환하는지 확인', async () => {
+		(fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => mockUser
+		});
+
+		const result = await getUserInfo(mockTeamId);
+		expect(result).toEqual(mockUser);
+		expect(fetch).toHaveBeenCalledWith(expect.stringContaining(mockTeamId), expect.any(Object));
+	});
+
+	test('getUserInfo는 401 에러 시 인증 필요 메시지가 나오는지 확인', async () => {
+		(fetch as jest.Mock).mockResolvedValueOnce({
+			ok: false,
+			status: 401,
+			json: async () => ({ code: 'UNAUTHORIZED', message: '인증이 필요합니다' })
+		});
+
+		await expect(getUserInfo(mockTeamId)).rejects.toThrow('인증이 필요합니다');
+
+		expect(fetch).toHaveBeenCalledWith(expect.stringContaining(mockTeamId), expect.any(Object));
+	});
+
+	test('getUSerInfo는 사용자가 없을시 시 404 에러가 나오는지 확인', async () => {
+		(fetch as jest.Mock).mockResolvedValueOnce({
+			ok: false,
+			status: 404,
+			json: async () => ({ code: 'USER_NOT_FOUND', message: '사용자를 찾을 수 없습니다' })
+		});
+
+		await expect(getUserInfo(mockTeamId)).rejects.toThrow('사용자를 찾을 수 없습니다');
+
+		expect(fetch).toHaveBeenCalledWith(expect.stringContaining(mockTeamId), expect.any(Object));
+	});
+
+	test('updateUserInfo는 PUT 요청을 보내고 업데이트 된 데이터를 반환하는지 확인', async () => {
+		const updatedData = { companyName: 'Codeit2', image: '/Codeit2.png' };
+		const updatedUser = { ...mockUser, ...updatedData };
+
+		(fetch as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => updatedUser
+		});
+
+		const result = await updateUserInfo(mockTeamId, updatedData);
+
+		expect(result).toEqual(updatedUser);
+		expect(fetch).toHaveBeenCalledWith(
+			expect.stringContaining(mockTeamId),
+			expect.objectContaining({ method: 'PUT', body: JSON.stringify(updatedData) })
+		);
+	});
+
+	test('updateUserInfo는 400 에러 시 유효성 검사가 나오는지 확인', async () => {
+		const updatedData = { email: 'invalid-email' };
+
+		(fetch as jest.Mock).mockResolvedValueOnce({
+			ok: false,
+			status: 400,
+			json: async () => ({
+				code: 'VALIDATION_ERROR',
+				parameter: 'email',
+				message: '유효한 입력 값을 제공해야 합니다'
+			})
+		});
+
+		await expect(updateUserInfo(mockTeamId, updatedData)).rejects.toThrow('유효한 입력 값을 제공해야 합니다');
+	});
+
+	test('updateUserInfo는 401 에러 시 인증 필요 메시지가 나오는지 확인', async () => {
+		const updatedData = { companyName: 'Codeit2' };
+
+		(fetch as jest.Mock).mockResolvedValueOnce({
+			ok: false,
+			status: 401,
+			json: async () => ({
+				code: 'UNAUTHORIZED',
+				message: '인증이 필요합니다'
+			})
+		});
+
+		await expect(updateUserInfo(mockTeamId, updatedData)).rejects.toThrow('인증이 필요합니다');
+	});
+
+	test('updateUserInfo는 404 에러 시 사용자 없음 메시지가 나오는지 확인', async () => {
+		const updatedData = { companyName: 'Codeit2' };
+
+		(fetch as jest.Mock).mockResolvedValueOnce({
+			ok: false,
+			status: 404,
+			json: async () => ({
+				code: 'USER_NOT_FOUND',
+				message: '사용자를 찾을 수 없습니다'
+			})
+		});
+
+		await expect(updateUserInfo(mockTeamId, updatedData)).rejects.toThrow('사용자를 찾을 수 없습니다');
+	});
+});

--- a/src/apis/users/index.ts
+++ b/src/apis/users/index.ts
@@ -2,19 +2,37 @@ import { getRequest, putRequest } from '@/apis';
 import { UserInfo } from '@/types/user';
 
 interface UpdateUserInfoProps {
-    companyName?: string;
+	companyName?: string;
 	image?: string;
-    email?: string;
+	email?: string;
 }
 
-// 사용자 정보 조회
+/**
+ * 팀의 사용자 정보를 조회합니다.
+ *
+ * @param {string} teamId - 조회할 팀 ID
+ * @returns {Promise<UserInfo>} 조회된 사용자 정보
+ *
+ * @example
+ * getUserInfo('1').then(user => console.log(user.name));
+ */
 export const getUserInfo = (teamId: string) => {
 	return getRequest<UserInfo>({
 		path: `/${teamId}/auths/user`
 	});
 };
 
-// 사용자 정보 수정
+/**
+ * 팀의 사용자 정보를 수정합니다.
+ *
+ * @param {string} teamId - 수정할 팀 ID
+ * @param {UpdateUserInfoProps} updatedData - 수정할 사용자 정보
+ * @returns {Promise<UserInfo>} 수정 후 반환된 사용자 정보
+ *
+ * @example
+ * updateUserInfo('123', { companyName: 'New Company' })
+ *   .then(user => console.log(user.companyName));
+ */
 export const updateUserInfo = (teamId: string, updatedData: UpdateUserInfoProps) => {
 	return putRequest<UserInfo, UpdateUserInfoProps>({
 		path: `/${teamId}/auths/user`,

--- a/src/apis/users/index.ts
+++ b/src/apis/users/index.ts
@@ -1,0 +1,23 @@
+import { getRequest, putRequest } from '@/apis';
+import { UserInfo } from '@/types/user';
+
+interface UpdateUserInfoProps {
+    companyName?: string;
+	image?: string;
+    email?: string;
+}
+
+// 사용자 정보 조회
+export const getUserInfo = (teamId: string) => {
+	return getRequest<UserInfo>({
+		path: `/${teamId}/auths/user`
+	});
+};
+
+// 사용자 정보 수정
+export const updateUserInfo = (teamId: string, updatedData: UpdateUserInfoProps) => {
+	return putRequest<UserInfo, UpdateUserInfoProps>({
+		path: `/${teamId}/auths/user`,
+		data: updatedData
+	});
+};

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,0 +1,14 @@
+// 마이페이지
+
+import ProfileEditCard from '@/components/me/ProfileEditCard';
+
+export default function Home() {
+	return (
+		<div className="box-border bg-gray-100" style={{ fontFamily: 'var(--font-pretendard)' }}>
+			<div className="tb:px-6 tb:pt-8 pc:max-w-300 pc:px-25 m-auto min-h-[100vh] bg-white px-4 pt-6">
+				<div className="mb-4 text-lg font-semibold text-gray-900">마이페이지</div>
+				<ProfileEditCard />
+			</div>
+		</div>
+	);
+}

--- a/src/components/me/MyActivityContainer/index.tsx
+++ b/src/components/me/MyActivityContainer/index.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function MyActivityContainer() {
+	const [activeTab, setActiveTab] = useState('meeting');
+
+	return (
+		<div className="tb:px-6 border-t-2 border-gray-900 px-4 py-6">
+			{/* 나의 모임, 나의 리뷰, 내가 만든 모임 탭 메뉴 */}
+			<div className="mb-6 flex gap-3 text-lg font-semibold tracking-normal">
+				<button
+					type="button"
+					onClick={() => setActiveTab('meeting')}
+					className={
+						activeTab === 'meeting'
+							? 'border-b-2 border-gray-900 pb-1.5 text-gray-900'
+							: 'border-b-2 border-transparent pb-1.5 text-gray-400'
+					}>
+					나의 모임
+				</button>
+				<button
+					onClick={() => setActiveTab('review')}
+					type="button"
+					className={
+						activeTab === 'review'
+							? 'border-b-2 border-gray-900 pb-1.5 text-gray-900'
+							: 'border-b-2 border-transparent pb-1.5 text-gray-400'
+					}>
+					나의 리뷰
+				</button>
+				<button
+					type="button"
+					onClick={() => setActiveTab('myMeeting')}
+					className={
+						activeTab === 'myMeeting'
+							? 'border-b-2 border-gray-900 pb-1.5 text-gray-900'
+							: 'border-b-2 border-transparent pb-1.5 text-gray-400'
+					}>
+					내가 만든 모임
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/src/components/me/ProfileEditCard/Modal.tsx
+++ b/src/components/me/ProfileEditCard/Modal.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect } from 'react';
+import Image from 'next/image';
+
+interface ModalProps {
+	setModal: () => void;
+}
+
+export default function Modal({ setModal }: ModalProps) {
+	// 모달 내부를 클릭했을 때, 모달 창이 꺼지는 것 방지
+	function preventOffModal(event: React.MouseEvent) {
+		event.stopPropagation();
+	}
+
+	// 모달창이 뜬 상태에서는 뒤 화면 스크롤 방지
+	useEffect(() => {
+		document.body.style.overflow = 'hidden';
+		return () => {
+			document.body.style.overflow = 'auto';
+		};
+	}, []);
+
+	return (
+		/* Modal 외부 */
+		<div
+			className="fixed inset-0 z-40 flex h-full w-full items-center justify-center bg-gray-500/50"
+			onClick={setModal}>
+			{/* Modal 내부*/}
+			<div className="relative z-50 rounded-xl bg-white p-6" onClick={preventOffModal}>
+				<form className="text-base font-semibold">
+					<div className="mb-6 flex items-center justify-between">
+						<p className="text-lg text-gray-900">프로필 수정하기</p>
+						<button type="button" onClick={setModal} className="ml-2 cursor-pointer rounded p-1 text-sm">
+							<Image src="/images/ic_cancle.svg" alt="취소 버튼" width={24} height={24} />
+						</button>
+					</div>
+
+					<div className="mt-6">
+						<div className="text-gray-800">회사</div>
+						<div className="mt-3">
+							<input
+								id="company"
+								name="company"
+								placeholder="회사명"
+								className="w-full bg-gray-50 p-2.5 text-sm font-medium text-gray-800 placeholder-gray-400"
+							/>
+						</div>
+					</div>
+
+					<div className="mt-6 flex w-full items-center justify-center gap-4">
+						<button
+							type="button"
+							onClick={setModal}
+							className="tb:w-57 pointer-events-auto w-35 cursor-pointer rounded-xl border border-orange-600 py-2.5 text-orange-600 hover:border-orange-500 hover:text-orange-500 active:border-orange-700 active:text-orange-700">
+							취소
+						</button>
+
+						<button className="tb:w-57 w-35 cursor-pointer rounded-xl bg-orange-600 py-[11px] text-white hover:bg-orange-700 active:bg-orange-800 disabled:cursor-not-allowed disabled:bg-gray-400 disabled:text-white">
+							수정하기
+						</button>
+					</div>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/src/components/me/ProfileEditCard/ProfileAssets.ts
+++ b/src/components/me/ProfileEditCard/ProfileAssets.ts
@@ -1,0 +1,14 @@
+export const profileAssets = {
+	mobile: {
+		bg: { src: '/images/profile_bg_mobile.svg', width: 156, height: 46 },
+		edit: { src: '/images/profile_edit_mobile.svg', width: 56, height: 56 }
+	},
+	tablet: {
+		bg: { src: '/images/profile_bg_tablet.svg', width: 156, height: 38 },
+		edit: { src: '/images/profile_edit.svg', width: 56, height: 56 }
+	},
+	desktop: {
+		bg: { src: '/images/profile_bg_desktop.svg', width: 158, height: 48 },
+		edit: { src: '/images/profile_edit.svg', width: 56, height: 56 }
+	}
+};

--- a/src/components/me/ProfileEditCard/__test__/useScreenSize.test.tsx
+++ b/src/components/me/ProfileEditCard/__test__/useScreenSize.test.tsx
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react';
+import { useScreenSize } from '../useScreenSize';
+
+describe('useScreenSize', () => {
+	function resizeWindow(width: number) {
+		// window.innerWidth 변경
+		(window.innerWidth as number) = width;
+
+		// resize 이벤트
+		window.dispatchEvent(new Event('resize'));
+	}
+
+	test('초기 width에 따라 올바른 값이 반환되는지 확인', () => {
+		resizeWindow(400);
+		const { result } = renderHook(() => useScreenSize());
+
+		expect(result.current).toBe('mobile');
+	});
+
+	test('width가 745xp이면 tablet을 반환하는지 확인', () => {
+		resizeWindow(745);
+		const { result } = renderHook(() => useScreenSize());
+
+		expect(result.current).toBe('tablet');
+	});
+
+	test('width가 1201px이면 desktop을 반환하는지 확인', () => {
+		resizeWindow(1201);
+		const { result } = renderHook(() => useScreenSize());
+
+		expect(result.current).toBe('desktop');
+	});
+
+	test('resize 이벤트가 발생하면 상태가 업데이트 되는지 확인', () => {
+		const { result } = renderHook(() => useScreenSize());
+
+		act(() => {
+			resizeWindow(1201);
+		});
+
+		expect(result.current).toBe('desktop');
+
+		act(() => {
+			resizeWindow(400);
+		});
+
+		expect(result.current).toBe('mobile');
+	});
+});

--- a/src/components/me/ProfileEditCard/index.tsx
+++ b/src/components/me/ProfileEditCard/index.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import Image from 'next/image';
+import { useScreenSize } from './useScreenSize';
+import { profileAssets } from './ProfileAssets';
+import Modal from './Modal';
+
+export default function ProfileEditCard() {
+	// 프로필 사진 업로드 상태
+	const [modalStatus, setModalStatus] = useState(false); // Modal 상태
+	const screenSize = useScreenSize(); // 스크린 크기에 따라 모바일, 태블릿, 데스크탑 상태 관리
+
+	// 버튼을 누르면 Modal 상태 변화
+	function handleModalStatus() {
+		setModalStatus(!modalStatus);
+	}
+
+	const { bg, edit } = useMemo(() => profileAssets[screenSize], [screenSize]);
+
+	return (
+		<>
+			<div className="pc:mb-7.5 mb-4 overflow-hidden rounded-3xl border-2 border-gray-200">
+				{/* 프로필 수정 카드 배경 이미지 */}
+				<div className="relative flex items-center justify-between bg-orange-400 px-6 py-4 before:absolute before:bottom-1.5 before:left-0 before:h-0.5 before:w-full before:bg-orange-600 before:content-['']">
+					<Image
+						src={bg.src}
+						alt="프로필 배경 이미지"
+						width={bg.width}
+						height={bg.height}
+						className="tb:right-[157px] pc:right-[155px] absolute right-15 bottom-[6.5px]"
+					/>
+
+					{/* 프로필 사진 수정 버튼 */}
+					<label
+						htmlFor="profile-image-upload"
+						className="absolute top-12.5 flex h-16 w-16 cursor-pointer items-center justify-center rounded-4xl bg-white">
+						<Image
+							src={edit.src}
+							alt="프로필 사진 수정 이미지"
+							width={edit.width}
+							height={edit.height}
+							className="h-14 w-14 rounded-full object-cover"
+						/>
+						<input id="profile-image-upload" type="file" accept="image/*" className="hidden" />
+					</label>
+
+					<p className="text-pc z-10 font-semibold text-gray-900">내 프로필</p>
+
+					{/* 회사명 수정 버튼 */}
+					<button title="modal-button" type="button" onClick={handleModalStatus} className="z-10 cursor-pointer">
+						<Image src="/images/edit_large.svg" alt="회사명 수정 이미지" width={32} height={32} />
+					</button>
+				</div>
+
+				{/* 프로필 정보 */}
+				<div>
+					<div className="tb:pt-3 tb:pb-4 pt-3.5 pb-4.5 pl-23">
+						<div className="mb-2.5 text-gray-800">
+							<p className="text-base font-semibold">Name</p>
+						</div>
+
+						<div className="flex gap-1.5">
+							<p className="text-sm font-medium">company.</p>
+							<p className="text-sm font-normal text-gray-700">Company Name</p>
+						</div>
+
+						<div className="flex gap-1.5">
+							<p className="text-sm font-medium">E-mail.</p>
+							<p className="text-sm font-normal text-gray-700">Email</p>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			{/* 회사명 수정 Modal */}
+			{modalStatus && <Modal setModal={handleModalStatus} />}
+		</>
+	);
+}

--- a/src/components/me/ProfileEditCard/useScreenSize.tsx
+++ b/src/components/me/ProfileEditCard/useScreenSize.tsx
@@ -1,5 +1,18 @@
 import { useState, useEffect } from 'react';
 
+/**
+ * 현재 화면 크기를 기준으로 'mobile', 'tablet', 'desktop' 중 하나를 반환하는 커스텀 훅
+ *
+ * 화면 크기에 따라 자동으로 값이 업데이트됩니다.
+ *
+ * @returns {'mobile' | 'tablet' | 'desktop'} 현재 화면 크기
+ *
+ * @example
+ * const screenSize = useScreenSize();
+ * if (screenSize === 'desktop') {
+ *   console.log('데스크탑 레이아웃 사용');
+ * }
+ */
 export function useScreenSize() {
 	const [screenSize, setScreenSize] = useState<'mobile' | 'tablet' | 'desktop'>('mobile');
 

--- a/src/components/me/ProfileEditCard/useScreenSize.tsx
+++ b/src/components/me/ProfileEditCard/useScreenSize.tsx
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+
+export function useScreenSize() {
+	const [screenSize, setScreenSize] = useState<'mobile' | 'tablet' | 'desktop'>('mobile');
+
+	useEffect(() => {
+		function updateSize() {
+			const width = window.innerWidth;
+			if (width >= 1200) setScreenSize('desktop');
+			else if (width >= 744) setScreenSize('tablet');
+			else setScreenSize('mobile');
+		}
+
+		updateSize();
+		window.addEventListener('resize', updateSize);
+		return () => window.removeEventListener('resize', updateSize);
+	}, []);
+
+	return screenSize;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,10 +1,7 @@
 @import 'tailwindcss';
-<<<<<<< HEAD
 @import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
-=======
->>>>>>> d7249da (Style : 색상 및 폰트 커스텀 + breakpoint  설정)
 
 @theme {
 	/* font family */
@@ -65,11 +62,6 @@
 	--leading-2xl: 32px;
 	--leading-3xl: 36px;
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d7249da (Style : 색상 및 폰트 커스텀 + breakpoint  설정)
 	/* 굵기 */
 	--font-weight-light: 300;
 	--font-weight-regular: 400;
@@ -81,7 +73,6 @@
 	--breakpoint-mb: 375px; /* 모바일 */
 	--breakpoint-tb: 744px; /* 태블릿 */
 	--breakpoint-pc: 1200px; /* 데스크탑 */
-<<<<<<< HEAD
 }
 
 /* input[type :"number"] 화살표 제거 */
@@ -209,6 +200,4 @@ input[type='number']::-webkit-outer-spin-button {
 		@apply bg-background text-foreground;
 		@apply font-pretendard;
 	}
-=======
->>>>>>> d7249da (Style : 색상 및 폰트 커스텀 + breakpoint  설정)
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,7 +1,10 @@
 @import 'tailwindcss';
+<<<<<<< HEAD
 @import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
+=======
+>>>>>>> d7249da (Style : 색상 및 폰트 커스텀 + breakpoint  설정)
 
 @theme {
 	/* font family */
@@ -42,7 +45,7 @@
 	--color-gray-900: #111827;
 	--color-gray-950: #030712;
 
-  /* 커스텀 폰트 설정 */
+	/* 커스텀 폰트 설정 */
 
 	/* 사이즈 */
 	--text-xs: 12px;
@@ -64,6 +67,9 @@
 
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> d7249da (Style : 색상 및 폰트 커스텀 + breakpoint  설정)
 	/* 굵기 */
 	--font-weight-light: 300;
 	--font-weight-regular: 400;
@@ -75,6 +81,7 @@
 	--breakpoint-mb: 375px; /* 모바일 */
 	--breakpoint-tb: 744px; /* 태블릿 */
 	--breakpoint-pc: 1200px; /* 데스크탑 */
+<<<<<<< HEAD
 }
 
 /* input[type :"number"] 화살표 제거 */
@@ -202,4 +209,6 @@ input[type='number']::-webkit-outer-spin-button {
 		@apply bg-background text-foreground;
 		@apply font-pretendard;
 	}
+=======
+>>>>>>> d7249da (Style : 색상 및 폰트 커스텀 + breakpoint  설정)
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -42,7 +42,10 @@
 	--color-gray-900: #111827;
 	--color-gray-950: #030712;
 
-	/* 커스텀 폰트 설정 */
+  /* 빨강 색상 */
+  --color-red-600: #dc2626;
+
+  /* 커스텀 폰트 설정 */
 
 	/* 사이즈 */
 	--text-xs: 12px;
@@ -62,6 +65,7 @@
 	--leading-2xl: 32px;
 	--leading-3xl: 36px;
 
+<<<<<<< HEAD
 	/* 굵기 */
 	--font-weight-light: 300;
 	--font-weight-regular: 400;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -42,9 +42,6 @@
 	--color-gray-900: #111827;
 	--color-gray-950: #030712;
 
-  /* 빨강 색상 */
-  --color-red-600: #dc2626;
-
   /* 커스텀 폰트 설정 */
 
 	/* 사이즈 */
@@ -65,6 +62,7 @@
 	--leading-2xl: 32px;
 	--leading-3xl: 36px;
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 	/* 굵기 */
 	--font-weight-light: 300;

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,0 +1,10 @@
+export interface UserInfo {
+	teamId: number;
+	id: number;
+	name: string;
+	email: string;
+	companyName: string;
+	image?: string;
+	createdAt: string;
+	updatedAt: string;
+}

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,10 +1,30 @@
+/**
+ * 사용자 정보를 나타내는 인터페이스
+ *
+ * @interface UserInfo
+ */
 export interface UserInfo {
+	/** 소속 팀 ID */
 	teamId: number;
+
+	/** 사용자 고유 ID */
 	id: number;
+
+	/** 사용자 이름 */
 	name: string;
+
+	/** 사용자 이메일 주소 */
 	email: string;
+
+	/** 사용자가 속한 회사 이름 */
 	companyName: string;
+
+	/** 사용자 프로필 이미지 URL (선택적) */
 	image?: string;
+
+	/** 사용자 정보 생성일시 (ISO 문자열) */
 	createdAt: string;
+
+	/** 사용자 정보 수정일시 (ISO 문자열) */
 	updatedAt: string;
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,11 @@
+// "M월 D일 · HH:mm" 형태 문자열로 전환하는 유틸 함수
+export function formatKoreanDate(dateString: string) {
+	const date = new Date(dateString);
+
+	const month = date.getMonth() + 1;
+	const day = date.getDate(); // getDay()는 요일(0~6) → 날짜는 getDate() 사용
+	const hours = date.getHours().toString().padStart(2, '0');
+	const minutes = date.getMinutes().toString().padStart(2, '0');
+
+	return `${month}월 ${day}일 · ${hours}:${minutes}`;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,13 @@
-// "M월 D일 · HH:mm" 형태 문자열로 전환하는 유틸 함수
+/**
+ * 주어진 날짜 문자열을 "M월 D일 · HH:mm" 형식으로 변환합니다.
+ *
+ * @param {string} dateString - 변환할 날짜 문자열 (예: "2025-09-26T14:30:00").
+ * @returns {string} 변환된 한국식 날짜 문자열 (예: "9월 26일 · 14:30").
+ *
+ * @example
+ * formatKoreanDate("2025-09-26T14:30:00");
+ * // 반환: "9월 26일 · 14:30"
+ */
 export function formatKoreanDate(dateString: string) {
 	const date = new Date(dateString);
 


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- [TD-24 마이페이지 제작](https://fesi11-team5.atlassian.net/browse/TD-24)
- [TD-31 프로필 수정 UI 컴포넌트 제작](https://fesi11-team5.atlassian.net/browse/TD-31)
- [TD-33 프로필 조회 및 수정 API 기능 구현](https://fesi11-team5.atlassian.net/browse/TD-33)

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

### ProfileEditCard UI 제작
- 버튼, 모달 등 임시로 만들었기 때문에 후에 공통 컴포넌트로 수정하겠습니다.
- UI만 제작했기 때문에 이름 / 회사명 / 이메일 같은 경우, 더미 텍스트로 표현했습니다.
- 현재 회사명 변경, 프로필 사진 변경과 같은 실질적인 기능은 연동되지 않습니다. API를 연동하면 구현할 예정입니다.

### useScreenSize 커스텀 훅 생성
- 컴포넌트 내부에 `useScreenSize` 훅을 생성했습니다.
- 제작 이유는 화면에 따라 배너의 이미지가 다른데, 하나의 파일에 구현하면 길이가 너무 길어졌습니다.
- `src, width, height`의 경우 컴포넌트 내부`ProfileAssets.ts`에서 별도로 관리합니다.

### 유저 정보 조회 및 변경 API 테스트 코드 작성
- `apis/users`에 유저 조회 및 수정 API 테스트 코드를 작성했습니다.
- 유저 정보 조회 및 수정 성공과 에러 처리(유저 정보 조회: 401, 404 / 유저 정보 수정: 400, 401, 404)를 테스트를 완료했습니다.

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->
- 이번 PR은 UI 및 API 테스트 코드 작성이 중심이며, API 연동 및 기능 개발은 추후 PR에서 진행 예정입니다.

### 체크리스트
- [x] ProfileEditCard UI 제작
- [x] 유저 API 테스트 코드 작성
- [ ] API 연동 및 기능 개발(추후 예정)

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

| Desktop | 
| --------- | 
| <img width="960" height="350" alt="ProfileEditCard_Desktop" src="https://github.com/user-attachments/assets/6c03bd62-8623-4e8c-9089-ab6ac2eb019f" /> | 

| Tablet | Mobile + Modal |
| ------- | ------------------|
| <img width="744" height="800" alt="ProfileEditCard_Tablet" src="https://github.com/user-attachments/assets/ce81e27c-7fd2-493b-aac0-fef7e0296045" /> | <img width="375" height="700" alt="ProfileEditCard_Mobile_Modal" src="https://github.com/user-attachments/assets/ad9cba80-0c21-4399-8264-14b21a16ff63" /> | 