### PR TITLE
TD-187 내가 만든 모임 페이지 생성

### DIFF
--- a/src/components/me/MyActivityContainer/CreatedGathering/index.tsx
+++ b/src/components/me/MyActivityContainer/CreatedGathering/index.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import CardLayout from '../common/CardLayout';
+import { getGatherings } from '@/apis/gatherings';
+import { Gathering } from '@/types/response/gatherings';
+import { useUserStore } from '@/stores/user';
+import { useRouter } from 'next/navigation';
+
+export default function CreatedGatherings() {
+	const { user } = useUserStore();
+	const router = useRouter();
+	const [gatherings, setGatherings] = useState<Gathering[]>([]);
+
+	useEffect(() => {
+		const fetchGatherings = async () => {
+			const data = await getGatherings(`createdBy=${user?.userId}`);
+			setGatherings(data as Gathering[]);
+		};
+		fetchGatherings();
+	}, []);
+
+	if (gatherings.length === 0) {
+		return (
+			<div className="flex h-full flex-1 items-center justify-center">
+				<p className="text-sm text-gray-500">아직 만든 모임이 없어요</p>
+			</div>
+		);
+	}
+
+	return gatherings.map(gathering => (
+		<div onClick={() => router.push(`/gatherings/${gathering.id}`)} key={gathering.id} className="cursor-pointer">
+			<CardLayout gathering={gathering}></CardLayout>
+		</div>
+	));
+}

--- a/src/components/me/MyActivityContainer/common/CardLayout.tsx
+++ b/src/components/me/MyActivityContainer/common/CardLayout.tsx
@@ -1,11 +1,11 @@
 import Image from 'next/image';
 import { formatKoreanDate } from '@/utils/date';
-import { JoinedGathering } from '@/types/response/gatherings';
+import { JoinedGathering, Gathering } from '@/types/response/gatherings';
 import { ReactNode } from 'react';
 
 interface GatheringProps {
 	/** 표시할 모임 객체 */
-	gathering: JoinedGathering;
+	gathering: JoinedGathering | Gathering;
 
 	/** 카드에 표시할 뱃지 또는 추가 컨텐츠 */
 	badgeContent?: ReactNode;

--- a/src/components/me/MyActivityContainer/index.tsx
+++ b/src/components/me/MyActivityContainer/index.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import JoinedGatherings from './JoinedGatherings';
 import MyReviews from './MyReviews';
+import CreatedGathering from './CreatedGathering';
 
 type TabKey = 'JoinedGathering' | 'MyReview' | 'CreatedGathering';
 
@@ -50,6 +51,7 @@ export default function MyActivityContainer() {
 			{/* 각 탭 클릭 시 알맞는 컨텐츠 호출 */}
 			{activeTab === 'JoinedGathering' && <JoinedGatherings />}
 			{activeTab === 'MyReview' && <MyReviews />}
+			{activeTab === 'CreatedGathering' && <CreatedGathering />}
 		</div>
 	);
 }


### PR DESCRIPTION
## 📌 관련 이슈

- [TD-187 내가 만든 모임 페이지 생성](https://fesi11-team5.atlassian.net/browse/TD-187)

## 💭 작업 내용

마이페이지 - 내가 만든 모임 페이지 제작했습니다.
내가 만든 모임 클릭하면 모임 상세로 이동하는 라우터도 추가했습니다.
기타 반응형이나 틀은 common/CardLayout 컴포넌트 재사용했습니다.

## 🤔 참고 사항

사실 지훈님이 다 만들어두신 컴포넌트 조합만 하고 api 연결만 한거라 엄청 간단하게 작업했습니다!

*common/CardLayout 컴포넌트를 재사용하려니 gatherings props에 JoinedGathering 타입 뿐만 아니라 그냥 Gathering 타입으로도 전달 가능해야해서, 임의로 타입 추가만 했습니다! 지훈님이 괜찮으신지 봐주시면 좋을 것 같아요.

덕분에 엄청 빨리 작업햇습니다~~~!! 이제 진짜 사소한거랑 기획적용만 하면 되겟군요!

## 📸 스크린샷


<img width="1792" height="966" alt="스크린샷 2025-10-27 오후 12 53 09" src="https://github.com/user-attachments/assets/f2484bd3-ca50-42da-add4-fdf201665688" />
